### PR TITLE
protobuf: Add link to Prototool style guide

### DIFF
--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -11,3 +11,7 @@ Format with `prototool format`.
 ## Linter
 
 Lint with `prototool lint`.
+
+## Style guide
+
+Look to [Prototool style guide](https://github.com/uber/prototool/blob/master/etc/style/uber/uber.proto).


### PR DESCRIPTION
Prototool style guide is a well documented source file that contains
motivation and reasons behind choices in the style guide.