### PR TITLE
Add conventions for Rust

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,13 @@
+# Rust
+
+## Formatter
+
+Format with [rustfmt](https://github.com/rust-lang/rustfmt) using the default settings.
+
+## Linter
+
+Lint with [clippy](https://github.com/rust-lang/rust-clippy) using the default settings.
+
+## Style guide
+
+Look to [Rust lang style guide](https://doc.rust-lang.org/1.0.0/style/).


### PR DESCRIPTION
Refer to the Rust lang style guide and point out rustfmt as code formatter and clippy as linter.